### PR TITLE
Updated version of aframe-alongpath-component to latest version

### DIFF
--- a/registry.yml
+++ b/registry.yml
@@ -4,7 +4,7 @@ components:
     names: alongpath
     versions:
       0.3.0:
-        version: ^0.1.1
+        version: ^0.2.1
         path: dist/aframe-alongpath-component.min.js
 
   aframe-animation-component:


### PR DESCRIPTION
I forgot to update the npm package version in the other pull request after the updates. Fixing this here.