### PR TITLE
super-hands version for A-Frame v0.5.0

### DIFF
--- a/registry.yml
+++ b/registry.yml
@@ -185,6 +185,9 @@ components:
       0.4.0:
         version: 0.2.x
         path: dist/super-hands.min.js
+      0.5.0:
+        version: 0.3.x
+        path: dist/super-hands.min.js
 
 shaders:
 


### PR DESCRIPTION
Update to point to new versions of super-hands for A-Frame v0.5.x