### PR TITLE
add aframe-raytrace-component

### DIFF
--- a/registry.yml
+++ b/registry.yml
@@ -238,6 +238,13 @@ components:
       0.5.0:
         version: ^1.0.1
         path: dist/aframe-point-component.min.js
+  
+  aframe-raytrace-component:
+    names: raytrace
+    versions:
+      0.6.0:
+        version: ^1.0.0
+        path: dist/aframe-raytrace-component.min.js
 
   aframe-stats-in-vr-component:
     names: stats-in-vr

--- a/registry.yml
+++ b/registry.yml
@@ -242,8 +242,8 @@ components:
   aframe-raytrace-component:
     names: raytrace
     versions:
-      0.6.0:
-        version: ^1.0.0
+      0.4.0:
+        version: ^1.1.0
         path: dist/aframe-raytrace-component.min.js
 
   aframe-stats-in-vr-component:


### PR DESCRIPTION
This one's for a bit more of a technical crowd than my last component, but it's much simpler and is already basically stable as far as I can tell.

BTW, if there's a way to get a function called whenever an object is about to be drawn (i.e. twice per frame in VR mode), let me know and I'll take the camera matrix inverse thing out of the vertex shader and into javascript, would just make it that much simpler/shorter...