### PR TITLE
Add aframe-fps-look-controls-component

### DIFF
--- a/registry.yml
+++ b/registry.yml
@@ -128,6 +128,13 @@ components:
     versions:
       0.5.0:
         version: ^1.1.0
+        
+  aframe-fps-look-controls-component:
+    names: fps-look-controls
+    path: dist/fps-look-controls-component.min.js
+    versions:
+      1.0.1:
+        version: ^1.0.x
 
   aframe-gaze-control-component:
     names: gaze-control


### PR DESCRIPTION
Enables FPS-style looking: move the mouse to look around, without needing to hold the button down.